### PR TITLE
update workflows (#22)

### DIFF
--- a/.github/workflows/DeployProd.yml
+++ b/.github/workflows/DeployProd.yml
@@ -6,7 +6,22 @@ on:
         - main
 
 jobs:
-    deploy:
+     build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name : Login to Docker Hub
+              run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+            - name: Build Docker image
+              run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:${{ github.sha }} .
+            - name: Push Docker image
+              run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:${{ github.sha }}
+            - name: Tag latest Docker image with latest tag
+              run: docker tag ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:${{ github.sha }} ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:latest
+            - name: Push Docker image with latest tag
+              run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:latest
+     deploy:
         runs-on: ubuntu-latest
         steps:
         - name: Deploy Docker

--- a/.github/workflows/DeployStaging.yml
+++ b/.github/workflows/DeployStaging.yml
@@ -6,6 +6,21 @@ on:
         - develop
 
 jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name : Login to Docker Hub
+              run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+            - name: Build Docker image
+              run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:${{ github.sha }} .
+            - name: Push Docker image
+              run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:${{ github.sha }}
+            - name: Tag latest Docker image with latest tag
+              run: docker tag ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:${{ github.sha }} ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:latestdev
+            - name: Push Docker image with latest tag
+              run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:latestdev
     deploy:
         runs-on: ubuntu-latest
         steps:

--- a/.github/workflows/Test&Build.yml
+++ b/.github/workflows/Test&Build.yml
@@ -45,13 +45,5 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-            - name : Login to Docker Hub
-              run: echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
             - name: Build Docker image
               run: docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:${{ github.sha }} .
-            - name: Push Docker image
-              run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:${{ github.sha }}
-            - name: Tag latest Docker image with latest tag
-              run: docker tag ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:${{ github.sha }} ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:latest
-            - name: Push Docker image with latest tag
-              run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:latest


### PR DESCRIPTION
This pull request updates the CI/CD workflows to separate Docker image building and pushing into dedicated `build` jobs for both production and staging environments. Additionally, redundant Docker-related steps have been removed from the `Test&Build.yml` workflow.

### Workflow Updates for CI/CD:

* **Production Workflow (`.github/workflows/DeployProd.yml`)**: Added a new `build` job to handle Docker image building and pushing, including tagging the image as `latest`. This ensures the production workflow is modular and streamlined.
* **Staging Workflow (`.github/workflows/DeployStaging.yml`)**: Introduced a similar `build` job for staging, with the distinction of tagging the Docker image as `latestdev` instead of `latest`.

### Removal of Redundant Steps:

* **Test & Build Workflow (`.github/workflows/Test&Build.yml`)**: Removed Docker login, image building, and pushing steps, as these tasks are now handled in the dedicated `build` jobs in the production and staging workflows.