### PR TITLE
37 update workflows backfor need build before deploy

### DIFF
--- a/.github/workflows/DeployProd.yml
+++ b/.github/workflows/DeployProd.yml
@@ -23,6 +23,7 @@ jobs:
               run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:latest
      deploy:
         runs-on: ubuntu-latest
+        needs: build
         steps:
         - name: Deploy Docker
           run : curl ${{secrets.RENDER_DEPLOY_HOOK}}

--- a/.github/workflows/DeployStaging.yml
+++ b/.github/workflows/DeployStaging.yml
@@ -23,6 +23,7 @@ jobs:
               run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/feed-pulse-back:latestdev
     deploy:
         runs-on: ubuntu-latest
+        needs: build
         steps:
         - name: Deploy Docker
           run : curl ${{secrets.RENDER_DEPLOY_HOOK_DEVELOP}}

--- a/.github/workflows/Test&Build.yml
+++ b/.github/workflows/Test&Build.yml
@@ -27,6 +27,8 @@ jobs:
                     args: --timeout=30m
               - name: Run tests
                 run: go test -v -count=1 -p 4 -coverprofile=coverage.txt -covermode=atomic ./...
+                env:
+                    MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
     build:
         needs: test
         runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve dependency management and enhance security by introducing environment variables for sensitive data. The most important changes include adding dependencies between jobs and securely passing API keys to the test job.

### Workflow Dependency Management:
* [`.github/workflows/DeployProd.yml`](diffhunk://#diff-c6d576c3a8f19378c7ce4c4705d1d29e96d1b823a68a204772d4b6ca5ea8b931R26): Added a `needs: build` dependency to ensure the `deploy` job waits for the `build` job to complete.
* [`.github/workflows/DeployStaging.yml`](diffhunk://#diff-3f7d98e016bd10e24bc0762ef29bb5fcb062bcbcfc4f1a9c49c61f98558eeacaR26): Added a `needs: build` dependency to ensure the `deploy` job waits for the `build` job to complete.

### Security Enhancements:
* [`.github/workflows/Test&Build.yml`](diffhunk://#diff-b8ee9a2a3f6402172d6b0f83a3b55bac3ffeb742adae7592c3c1b67407ca25b3R30-R31): Added the `MISTRAL_API_KEY` environment variable to the `Run tests` step, securely passing the API key from GitHub Secrets.